### PR TITLE
Cursor fix

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -213,7 +213,7 @@ fn cursor_to_line_col(input: &str) -> OpResult {
         dual_int_parameter_sequence::<usize>('H'),
         dual_int_parameter_sequence::<usize>('f'),
     ))(input)
-    .map(|(rest, (a, b))| (rest, Op::MoveCursorAbs { x: b.saturating_sub(1) - 1, y: a.saturating_sub(1) }))
+    .map(|(rest, (a, b))| (rest, Op::MoveCursorAbs { x: b.saturating_sub(1), y: a.saturating_sub(1) }))
 }
 
 /// ESC [ <n> A         => Cursor up n lines

--- a/src/bin/vgaterm.rs
+++ b/src/bin/vgaterm.rs
@@ -10,7 +10,7 @@ use esp32c3_hal::prelude::*;
 use esp32c3_hal::timer::TimerGroup;
 use esp32c3_hal::{gpio::IO, peripherals::Peripherals, Rtc};
 use esp_println::{print, println};
-use vgaterm::{self, video};
+use vgaterm::{self, video, interrupt::Priority};
 use vgaterm::{usb_keyboard::US_ENGLISH, Delay, Work};
 
 use core::arch::asm;

--- a/src/bin/vgaterm.rs
+++ b/src/bin/vgaterm.rs
@@ -6,7 +6,6 @@ extern crate alloc;
 
 use alloc::collections::VecDeque;
 use esp32c3_hal::clock::{ClockControl, CpuClock};
-use esp32c3_hal::interrupt::Priority;
 use esp32c3_hal::prelude::*;
 use esp32c3_hal::timer::TimerGroup;
 use esp32c3_hal::{gpio::IO, peripherals::Peripherals, Rtc};
@@ -81,15 +80,15 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    io.pins.gpio20.into_floating_input();
+    // io.pins.gpio20.into_floating_input();
 
     init_heap();
     configure_counter_for_cpu_cycles();
 
     vgaterm::configure_timer0(peripherals.TIMG0, &clocks);
     let mut host_recv = vgaterm::uart::configure0(peripherals.UART0);
-    vgaterm::enable_timer0_interrupt(Priority::Priority1);
-    vgaterm::uart::interrupt_enable0(Priority::Priority2);
+    vgaterm::enable_timer0_interrupt(Priority::Priority5);
+    vgaterm::uart::interrupt_enable0(Priority::Priority6);
     vgaterm::gpio::interrupt_enable(Priority::max());
 
     unsafe {
@@ -159,6 +158,8 @@ fn main() -> ! {
     let mut key_state = vgaterm::keyboard::PressedSet::new();
     let mut input = vgaterm::terminal_input::TerminalInput::new(300, 40);
 
+    let local_echo = false;
+    let connect_host = true;
     loop {
         keyvents.extend(keyboard.flush_and_parse());
         if let Some(kevent) = keyvents.pop_front() {
@@ -173,7 +174,12 @@ fn main() -> ! {
         match last_char {
             Work::Item(ref c) => {
                 for c in c.chars() {
-                    print!("{}", c);
+                    if connect_host {
+                        print!("{}", c);
+                    }
+                    if local_echo {
+                        terminal.type_next(c);
+                    }
                 }
             }
             Work::WouldBlock => {}

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -102,7 +102,6 @@ impl Cursor {
 
     fn update(&mut self, text: &mut TextDisplay) {
         let now = SystemTimer::now();
-        // println!("now {}, upcoming time {}", now, self.time_to_next_blink);
         if now >= self.time_to_next_blink {
             self.time_to_next_blink = now.wrapping_add(self.blink_length);
             self.swap_highlight(text);

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,7 +1,7 @@
 use crate::{
     ansi::{EraseMode, Op, OpChar, TerminalEsc},
     color::Rgb3,
-    display::{self, Character, TextDisplay}, ansi::{TerminalEsc, OpChar, Op, EraseMode},
+    display::{self, Character, TextDisplay},
 };
 use embedded_graphics::prelude::DrawTarget;
 use esp32c3_hal::systimer::SystemTimer;

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -163,7 +163,7 @@ impl TextField {
                     },
 
                     '\u{7f}' => {}
-        
+         // taken from char::escape_default (below)
                     '\\' | '\'' | '"' => {
                         self.text
                             .write(self.cursor.pos.row(), self.cursor.pos.col(), t);


### PR DESCRIPTION
* I added two new escape sequences that seem to be used in my linux laptop. These were being sent I guess every time the PS1 prompt was being shown? But essentially I cover the entire set of private DEC sequences so we can choose to handle them or not.
* Some escape sequence issues where we go from 1-indexed in terminal escape land to 0 indexed when we go to our implementation of a matrix of characters were fixed
* local echo / connect to host hack variables for an ultra fast quick and dirty only-for-testing way of switching if we want to connect to send/recv data from a host and where we echo back our own key presses. Surely we want to do this a different way for real, this is severely temporary and not an actual idea of what we should do ha
* Lots of the Cursor logic as well as CharColor logic is (in my mind) much more simplified. The cursor was convoluted before. Now it's a more unified way of thinking (with one bit of hiccup we can think about). Now the cursor can be imagined as a floating window above a certain character in the field of text in the terminal. The cursor will highlight that character by periodically flipping the `Inverse` bit of the CharColor portion of the Character. This is done by reading the character, flipping the Inverse, and then saving it back. This requires the cursor have a mutable ref to the TextDisplay. The Cursor only affects the TextDisplay, the cursor essentially only knows where it is and how long it is until it flips Highlight state.
    * There is a wrinkle that with this implementation currently we assume that the text is never "inverted" so when we go to set it back after  the highlighted state we set it back to not inverted. I suppose that would be easy to fix in the near future.