### PR TITLE
perf: mem{cpy,set,move}, relink _start_trap, LTO

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,7 +152,7 @@ dependencies = [
 [[package]]
 name = "esp-hal-common"
 version = "0.7.1"
-source = "git+https://github.com/rustbox/esp-hal?rev=60d9a516be284c459eb236c1e093f5f7ac48dcb9#60d9a516be284c459eb236c1e093f5f7ac48dcb9"
+source = "git+https://github.com/rustbox/esp-hal?rev=f73e3f90deb93751fce8863f412ed7120d329b5d#f73e3f90deb93751fce8863f412ed7120d329b5d"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -172,7 +172,7 @@ dependencies = [
 [[package]]
 name = "esp-hal-procmacros"
 version = "0.4.0"
-source = "git+https://github.com/rustbox/esp-hal?rev=60d9a516be284c459eb236c1e093f5f7ac48dcb9#60d9a516be284c459eb236c1e093f5f7ac48dcb9"
+source = "git+https://github.com/rustbox/esp-hal?rev=f73e3f90deb93751fce8863f412ed7120d329b5d#f73e3f90deb93751fce8863f412ed7120d329b5d"
 dependencies = [
  "darling",
  "proc-macro-crate",
@@ -212,7 +212,7 @@ dependencies = [
 [[package]]
 name = "esp32c3-hal"
 version = "0.7.0"
-source = "git+https://github.com/rustbox/esp-hal?rev=60d9a516be284c459eb236c1e093f5f7ac48dcb9#60d9a516be284c459eb236c1e093f5f7ac48dcb9"
+source = "git+https://github.com/rustbox/esp-hal?rev=f73e3f90deb93751fce8863f412ed7120d329b5d#f73e3f90deb93751fce8863f412ed7120d329b5d"
 dependencies = [
  "cfg-if",
  "embedded-hal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ path  = "src/bin/keypad.rs"
 
 [profile.release]
 opt-level = 2
+lto       = true
 
 [profile.dev]
 debug     = true # Symbols are nice and they don't increase the size on Flash
@@ -40,7 +41,10 @@ critical-section = "1.1.1"
 embedded-graphics = "0.7.1"
 embedded-hal = "0.2"
 esp-alloc = { version = "0.2.0", features = ["oom-handler"] }
-esp-println = { version = "0.4.0", default-features = false, features = ["esp32c3", "jtag_serial"] }
+esp-println = { version = "0.4.0", default-features = false, features = [
+  "esp32c3",
+  "jtag_serial",
+] }
 esp32c3-hal = { features = [
   "direct-boot",
 ], version = "*" }
@@ -60,8 +64,7 @@ esp-backtrace = { version = "0.6.0", features = [
 
 [dev-dependencies]
 
-
 [patch.crates-io]
 # TODO: automate these updates
-esp32c3-hal    = { git = "https://github.com/rustbox/esp-hal", rev = "60d9a516be284c459eb236c1e093f5f7ac48dcb9" }
-esp-hal-common = { git = "https://github.com/rustbox/esp-hal", rev = "60d9a516be284c459eb236c1e093f5f7ac48dcb9" }
+esp32c3-hal    = { git = "https://github.com/rustbox/esp-hal", rev = "f73e3f90deb93751fce8863f412ed7120d329b5d" }
+esp-hal-common = { git = "https://github.com/rustbox/esp-hal", rev = "f73e3f90deb93751fce8863f412ed7120d329b5d" }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is targeted at the RISC-V architecture esp32-c3 processor from espressif. T
 
 `rustup target add riscv32imc-unknown-none-elf`
 
-3. Using Cargo, install the `espflash` tool which can upload and flash the code across a serial 
+3. Using Cargo, install the `espflash` tool which can upload and flash the code across a serial
 port (through usb) to the esp32 chip:
 
 `cargo install espflash`

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -125,6 +125,7 @@ impl Measure {
         }
     }
 
+    #[link_section = ".rwtext"]
     pub fn flush<const N: usize>(measures: [&mut Measure; N]) {
         for m in measures {
             if m.ticks < m.freq.to_Hz() {


### PR DESCRIPTION
memcpy & friends were previously living in the flash range, and consequently we were getting really inconsistent performance out of them (especially impactful since they're called everywhere, and were very large, and so would trash the heck out of the cache).

These straightforward, unoptimized implementations are now memory resident (and, bonus, small enough that LLVM/LTO are able to eliminate many of the calls entirely), which has been a huge boon to the consistency of performance.

On the minus side, I seem to have blown the carefully tuned timing for frame chunks, and, much more worrying, adding "too much" (or the wrong amount of?) code causes us to crash hard on startup. Just, don't change things?